### PR TITLE
Fix #16: Crashing very often

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, pypy3]
+        python-version: [3.7, 3.8, 3.9]
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/src/modbus_proxy.py
+++ b/src/modbus_proxy.py
@@ -166,7 +166,9 @@ class ModBus(Connection):
                     coro = self._write_read(data)
                     return await asyncio.wait_for(coro, self.timeout)
                 except Exception as error:
-                    self.log.error("write_read error: %r", error)
+                    self.log.error(
+                        "write_read error [%s/%s]: %r", i + 1, attempts, error
+                    )
                     await self.close()
 
     async def _write_read(self, data):

--- a/src/modbus_proxy.py
+++ b/src/modbus_proxy.py
@@ -135,10 +135,6 @@ class ModBus(Connection):
         self.server = None
         self.lock = asyncio.Lock()
 
-    async def close(self):
-        await self.stop()
-        await super().close()
-
     @property
     def address(self):
         if self.server is not None:
@@ -197,6 +193,7 @@ class ModBus(Connection):
         if self.server is not None:
             self.server.close()
             await self.server.wait_closed()
+        await self.close()
 
     async def serve_forever(self):
         if self.server is None:

--- a/tests/test_modbus_proxy.py
+++ b/tests/test_modbus_proxy.py
@@ -183,7 +183,7 @@ async def test_run(modbus_device):
         await make_request(modbus)
     finally:
         for bridge in ready.data:
-            await bridge.close()
+            await bridge.stop()
         try:
             await task
         except asyncio.CancelledError:


### PR DESCRIPTION
If there is a modbus communication error the server is being fully stopped which is wrong.

This PR changes that so instead only the modbus connection is closed