### PR TITLE
Fix error tox config file not found

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -63,3 +63,6 @@ replace = __version__ = "{new_version}"
 [flake8]
 max-line-length = 88
 extend-ignore = E203
+
+[tox:tox]
+envlist = py3


### PR DESCRIPTION
Fixes the following error while running tox:
 $ tox
 ERROR: tox config file (either pyproject.toml, tox.ini, setup.cfg) not found

 $ tox --version
 3.26.0 imported from /usr/lib/python3.10/site-packages/tox/__init__.py
 registered plugins:
     tox-current-env-0.0.8 at /usr/lib/python3.10/site-packages/tox_current_env/hooks.py

This happens for the tarball fetched from[1].

[1] https://files.pythonhosted.org/packages/source/m/modbus-proxy/modbus-proxy-0.6.8.tar.gz

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>