### PR TITLE
Support remapping unit IDs for wonky clients and servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ devices:
     connection_time: 0.1       # delay after connection (s) (optional, default: 0)
   listen:
     bind: 0:9000               # listening address (mandatory)
+  unit_id_remapping:           # remap/forward unit IDs (optional, empty by default)
+    1: 0
 ```
 
 Assuming you saved this file as `modbus-config.yml`, start the server with:
@@ -81,6 +83,21 @@ modbus-proxy -b tcp://0:9000 --modbus tcp://plc1.acme.org:502
 
 (hint: run `modbus-proxy --help` to see all available options)
 
+### Forwarding Unit Identifiers
+
+You can also forward one unit ID to another whilst proxying. This is handy if the target
+modbus server has a unit on an index that is not supported by one of your clients.
+
+```yaml
+devices:
+- modbus: ... # see above.
+  listen: ... # see above.
+  unit_id_remapping:
+    1: 0
+```
+
+The above forwards requests to unit ID 1 to your modbus-proxy server to unit ID 0 on the
+actual modbus server.
 
 ## Running the examples
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ devices:
 The above forwards requests to unit ID 1 to your modbus-proxy server to unit ID 0 on the
 actual modbus server.
 
+Note that **the reverse also applies**: if you forward unit ID 1 to unit ID 0, **all** responses coming from unit 0 will look as if they are coming from 1, so this may pose problems if you want to use unit ID 0 for some clients and unit ID 1 for others (use unit ID 1 for all in that case).
+
 ## Running the examples
 
 To run the examples you will need to have

--- a/src/modbus_proxy.py
+++ b/src/modbus_proxy.py
@@ -132,7 +132,7 @@ class ModBus(Connection):
         self.modbus_port = url.port
         self.timeout = modbus.get("timeout", None)
         self.connection_time = modbus.get("connection_time", 0)
-        self.unit_id_remapping = config.get("unit_id_remapping", {})  or {}
+        self.unit_id_remapping = config.get("unit_id_remapping") or {}
         self.server = None
         self.lock = asyncio.Lock()
 

--- a/src/modbus_proxy.py
+++ b/src/modbus_proxy.py
@@ -178,7 +178,7 @@ class ModBus(Connection):
         if self.unit_id_remapping is None:
             return request
 
-        if self.unit_id_remapping[request_unit_id] is None:
+        if request_unit_id not in self.unit_id_remapping:
             return request
 
         remapped_unit_id = self.unit_id_remapping[request_unit_id]

--- a/src/modbus_proxy.py
+++ b/src/modbus_proxy.py
@@ -183,7 +183,7 @@ class ModBus(Connection):
 
         remapped_unit_id = self.unit_id_remapping[request_unit_id]
 
-        self.log.info("remapping unit ID %s to %s", request_unit_id, remapped_unit_id)
+        self.log.debug("remapping unit ID %s to %s", request_unit_id, remapped_unit_id)
 
         request = request[:6] + bytearray([remapped_unit_id]) + request[7:]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,15 @@ REQ2 = b"m\xf5\x00\x00\x00\x06\x01\x03\x00\x02\x00\x03"
 REP2 = b"m\xf5\x00\x00\x00\x09\x01\x03\x08\x00\x02\x00\x03\x00\x04"
 
 
+# read_holding_registers(unit=1, start=2, size=3)
+#       |tid | tcp   | size  |uni|cod|s .addr|nb. reg|
+REQ3_ORIGINAL = b"m\xf5\x00\x00\x00\x06\xFF\x03\x00\x02\x00\x03"
+REQ3_MODIFIED = b"m\xf5\x00\x00\x00\x06\xFE\x03\x00\x02\x00\x03"
+#       |tid | tcp   | size  |uni|cod|len|   2   |   3   |   4   |
+REP3_ORIGINAL = b"m\xf5\x00\x00\x00\x09\xFE\x03\x08\x00\x02\x00\x03\x00\x04"
+REP3_MODIFIED = b"m\xf5\x00\x00\x00\x09\xFF\x03\x08\x00\x02\x00\x03\x00\x04"
+
+
 @pytest.fixture
 async def modbus_device():
     async def cb(r, w):
@@ -29,6 +38,9 @@ async def modbus_device():
                 reply = REP
             elif data == REQ2:
                 reply = REP2
+            elif data == REQ3_MODIFIED:
+                reply = REP3_ORIGINAL
+
             w.write(reply)
             await w.drain()
 
@@ -45,6 +57,7 @@ def modbus_config(modbus_device):
     return {
         "modbus": {"url": "{}:{}".format(*modbus_device.address)},
         "listen": {"bind": "127.0.0.1:0"},
+        "unit_id_remapping": {255: 254},
     }
 
 

--- a/tests/test_modbus_proxy.py
+++ b/tests/test_modbus_proxy.py
@@ -20,7 +20,7 @@ import pytest
 
 from modbus_proxy import parse_url, parse_args, load_config, run
 
-from .conftest import REQ, REP, REQ2, REP2
+from .conftest import REQ, REP, REQ2, REP2, REQ3_ORIGINAL, REP3_MODIFIED
 
 
 Args = namedtuple(
@@ -155,8 +155,9 @@ async def make_requests(modbus, requests):
     [
         (REQ, REP),
         (REQ2, REP2),
+        (REQ3_ORIGINAL, REP3_MODIFIED),
     ],
-    ids=["req1", "req2"],
+    ids=["req1", "req2", "req3"],
 )
 @pytest.mark.asyncio
 async def test_modbus(modbus, req, rep):


### PR DESCRIPTION
Some clients require a minimum unit ID of 1 (e.g. Loxone home automation's MODBUS server support), and some servers have a device on unit ID 0 (e.g. Huawei SUN-2000L), making both incompatible. Ideally they should support one another, but when wonky implementations such as these don't, with this PR you can let the proxy remap one unit ID to another to fix this.

Marking this as draft since I've already tested this working with qModMaster, but still need to test on-device to ensure it actually fixes my problem :wink: .

Fixes #25.