### PR TITLE
Fix incorrect PYTHONPATH during tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ python =
 
 [testenv]
 setenv =
-    PYTHONPATH = {toxinidir}
+    PYTHONPATH = {toxinidir}/src
 deps =
     -r{toxinidir}/requirements_dev.txt
 commands =


### PR DESCRIPTION
Fixes running tests:
  ImportError while loading conftest '/home/dw/projects/modbus/modbus-proxy/tests/conftest.py'.
  tests/conftest.py:5: in <module>
      from modbus_proxy import ModBus
  E   ModuleNotFoundError: No module named 'modbus_proxy'
  py312: exit 4 (0.52 seconds) /home/dw/projects/modbus/modbus-proxy> pytest --basetemp=/home/dw/projects/modbus/modbus-proxy/.tox/py312/tmp pid=95087
    py312: FAIL code 4 (0.53 seconds)
    evaluation failed :( (0.65 seconds)