### PR TITLE
Relax minimum required version of dependencies

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,8 +1,8 @@
-bumpversion==0.6.0
-pytest==8.3.2
-pytest-asyncio==0.24.0
-pytest-cov==5.0.0
-tox==4.18.0
-flake8==3.9.2
-toml==0.10.2
-pyyaml==6.0.2
+bumpversion>=0.6.0
+pytest>=7.4.3
+pytest-asyncio>=0.23.5
+pytest-cov>=4.0.0
+tox>=4.16.0
+flake8>=3.9.2
+toml>=0.10.2
+pyyaml>=6.0.1


### PR DESCRIPTION
At least to those available in Fedora 40.