### PR TITLE
Add connection ID to track requests and responses in log

### DIFF
--- a/src/modbus_proxy.py
+++ b/src/modbus_proxy.py
@@ -11,6 +11,7 @@ import pathlib
 import argparse
 import warnings
 import contextlib
+import hashlib
 import logging.config
 from urllib.parse import urlparse
 
@@ -114,9 +115,9 @@ class Connection:
 
 
 class Client(Connection):
-    def __init__(self, reader, writer):
+    def __init__(self, reader, writer, modbus_id):
         peer = writer.get_extra_info("peername")
-        super().__init__(f"Client({peer[0]}:{peer[1]})", reader, writer)
+        super().__init__(f"Client({peer[0]}:{peer[1]}, {modbus_id})", reader, writer)
         self.log.info("new client connection")
 
 
@@ -125,7 +126,8 @@ class ModBus(Connection):
         modbus = config["modbus"]
         url = parse_url(modbus["url"])
         bind = parse_url(config["listen"]["bind"])
-        super().__init__(f"ModBus({url.hostname}:{url.port})", None, None)
+        self.id = hashlib.sha1(modbus["url"].encode()).hexdigest()[:6]
+        super().__init__(f"ModBus({url.hostname}:{url.port}, {self.id})", None, None)
         self.host = bind.hostname
         self.port = 502 if bind.port is None else bind.port
         self.modbus_host = url.hostname
@@ -192,7 +194,7 @@ class ModBus(Connection):
         return reply
 
     async def handle_client(self, reader, writer):
-        async with Client(reader, writer) as client:
+        async with Client(reader, writer, self.id) as client:
             while True:
                 request = await client.read()
                 if not request:


### PR DESCRIPTION
Having more than one device in config file, it was hard for me to track which clients communicate with which device, so I added a simple ID to the `name` of each connection in order the have that ID printed in every line of log. The ID is derived from `url` of modbus device.

```
INFO modbus-proxy.ModBus(192.168.0.10:502, 8ce6dd): Ready to accept requests on 0:11120
INFO modbus-proxy.ModBus(192.168.0.11:502, a633f1): Ready to accept requests on 0:11121
INFO modbus-proxy.Client(127.0.0.1:57240, 8ce6dd): new client connection
DEBUG modbus-proxy.Client(127.0.0.1:57240, 8ce6dd): received b'\x96\xac\x00\x00\x00\x06\x01\x03\x9c\x87\x00&'
INFO modbus-proxy.ModBus(192.168.0.10:502, 8ce6dd): connecting to modbus...
INFO modbus-proxy.ModBus(192.168.0.10:502, 8ce6dd): connected!
INFO modbus-proxy.ModBus(192.168.0.10:502, 8ce6dd): delay after connect: 0.5
INFO modbus-proxy.Client(127.0.0.1:43987, a633f1): new client connection
DEBUG modbus-proxy.Client(127.0.0.1:43987, a633f1): received b'\x96\xac\x00\x00\x00\x06\x01\x03\x9c\x87\x00&'
```
