### PR TITLE
Optional mode for RTU over TCP

### DIFF
--- a/src/modbus_proxy.py
+++ b/src/modbus_proxy.py
@@ -188,6 +188,7 @@ class ModBus(Connection):
         self.timeout = modbus.get("timeout", None)
         self.connection_time = modbus.get("connection_time", 0)
         self.rtu = modbus.get("mode", "tcp") == "rtuovertcp"
+        self.rtu_echo = self.rtu and modbus.get("strip_rtu_echo", False)
         self.unit_id_remapping = config.get("unit_id_remapping") or {}
         self.server = None
         self.lock = asyncio.Lock()
@@ -226,7 +227,10 @@ class ModBus(Connection):
 
     async def _write_read(self, data):
         if self.rtu:
-            await self._write(tcp_to_rtu(data))
+            rtu_request = tcp_to_rtu(data)
+            await self._write(rtu_request)
+            if self.rtu_echo:
+                await self.reader.readexactly(len(rtu_request))
             return rtu_to_tcp(data[:2], await self._read_rtu())
         await self._write(data)
         return await self._read()

--- a/src/modbus_proxy.py
+++ b/src/modbus_proxy.py
@@ -31,6 +31,61 @@ DEFAULT_LOG_CONFIG = {
 log = logging.getLogger("modbus-proxy")
 
 
+def crc16(data):
+    """Compute Modbus CRC-16 checksum."""
+    crc = 0xFFFF
+    for byte in data:
+        crc ^= byte
+        for _ in range(8):
+            if crc & 1:
+                crc = (crc >> 1) ^ 0xA001
+            else:
+                crc >>= 1
+    return crc
+
+
+def tcp_to_rtu(tcp_frame):
+    """Strip the 6-byte MBAP header and append a CRC to form an RTU frame."""
+    body = tcp_frame[6:]
+    return body + crc16(body).to_bytes(2, "little")
+
+
+RTU_MIN_FRAME = 4    # uid(1) + fc(1) + CRC(2) — shortest valid RTU frame
+RTU_MAX_FRAME = 256  # hard safety cap
+
+
+async def read_rtu_frame(reader: asyncio.StreamReader) -> bytes:
+    """Read exactly one RTU frame from *reader* and return it (CRC included).
+
+    RTU has no length field in its framing — the CRC is the canonical frame
+    delimiter.  We accumulate bytes one at a time and stop as soon as
+    crc16(accumulated) == 0, which is the standard property of CRC-16 over a
+    complete, correctly-framed message (payload + CRC bytes).
+
+    This requires no knowledge of function-code-specific payload layouts and
+    handles every function code — standard reads/writes, fixed-length write
+    acknowledgements, and Huawei's private 0x41 — identically.
+
+    Raises asyncio.TimeoutError if the caller wraps this in wait_for().
+    Raises ValueError if RTU_MAX_FRAME bytes arrive without a valid CRC.
+    """
+    frame = bytearray()
+    while len(frame) < RTU_MAX_FRAME:
+        frame += await reader.readexactly(1)
+        if len(frame) >= RTU_MIN_FRAME and crc16(bytes(frame)) == 0:
+            return bytes(frame)
+    raise ValueError(
+        f"no valid RTU frame CRC found within {RTU_MAX_FRAME} bytes; "
+        f"partial frame: {bytes(frame).hex()}"
+    )
+
+
+def rtu_to_tcp(tid, rtu_frame):
+    """Strip the trailing CRC and prepend an MBAP header to form a TCP frame."""
+    body = rtu_frame[:-2]
+    return tid + b"\x00\x00" + len(body).to_bytes(2, "big") + body
+
+
 def parse_url(url):
     if "://" not in url:
         url = f"tcp://{url}"
@@ -91,8 +146,8 @@ class Connection:
         return True
 
     async def _read(self):
-        """Read ModBus TCP message"""
-        # TODO: Handle Modbus RTU and ASCII
+        """Read a Modbus TCP frame."""
+        # TODO: Handle Modbus ASCII
         header = await self.reader.readexactly(6)
         size = int.from_bytes(header[4:], "big")
         reply = header + await self.reader.readexactly(size)
@@ -132,6 +187,7 @@ class ModBus(Connection):
         self.modbus_port = url.port
         self.timeout = modbus.get("timeout", None)
         self.connection_time = modbus.get("connection_time", 0)
+        self.rtu = modbus.get("mode", "tcp") == "rtuovertcp"
         self.unit_id_remapping = config.get("unit_id_remapping") or {}
         self.server = None
         self.lock = asyncio.Lock()
@@ -169,8 +225,17 @@ class ModBus(Connection):
                     await self.close()
 
     async def _write_read(self, data):
+        if self.rtu:
+            await self._write(tcp_to_rtu(data))
+            return rtu_to_tcp(data[:2], await self._read_rtu())
         await self._write(data)
         return await self._read()
+
+    async def _read_rtu(self):
+        """Read a Modbus RTU reply frame from the device."""
+        frame = await read_rtu_frame(self.reader)
+        self.log.debug("received RTU %r", frame)
+        return frame
 
     def _transform_request(self, request):
         uid = request[6]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,12 +39,19 @@ REQ2_RTU = tcp_to_rtu(REQ2)
 REP2_RTU = tcp_to_rtu(REP2)
 
 
+async def _make_device(cb):
+    server = await asyncio.start_server(cb, host="127.0.0.1")
+    server.address = server.sockets[0].getsockname()
+    return server
+
+
 async def _read_rtu_request(r):
     """Read one RTU request frame from the fake device stream."""
     return await read_rtu_frame(r)
 
 
 RTU_REPLIES = {REQ_RTU: REP_RTU, REQ2_RTU: REP2_RTU}
+TCP_REPLIES = {REQ: REP, REQ2: REP2, REQ3_MODIFIED: REP3_ORIGINAL}
 
 
 @pytest_asyncio.fixture
@@ -55,9 +62,8 @@ async def modbus_device_rtu():
             w.write(RTU_REPLIES[data])
             await w.drain()
 
+    server = await _make_device(cb)
     try:
-        server = await asyncio.start_server(cb, host="127.0.0.1")
-        server.address = server.sockets[0].getsockname()
         yield server
     finally:
         server.close()
@@ -82,25 +88,52 @@ async def modbus_rtu(modbus_device_rtu):
 
 
 @pytest_asyncio.fixture
+async def modbus_device_rtu_echo():
+    async def cb(r, w):
+        while True:
+            data = await _read_rtu_request(r)
+            w.write(data)  # echo the request back first
+            w.write(RTU_REPLIES[data])
+            await w.drain()
+
+    server = await _make_device(cb)
+    try:
+        yield server
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+@pytest_asyncio.fixture
+async def modbus_rtu_echo(modbus_device_rtu_echo):
+    cfg = {
+        "modbus": {
+            "url": "{}:{}".format(*modbus_device_rtu_echo.address),
+            "mode": "rtuovertcp",
+            "strip_rtu_echo": True,
+        },
+        "listen": {"bind": "127.0.0.1:0"},
+    }
+    modbus = ModBus(cfg)
+    await modbus.start()
+    modbus.device = modbus_device_rtu_echo
+    async with modbus:
+        yield modbus
+    modbus_device_rtu_echo.close()
+
+
+@pytest_asyncio.fixture
 async def modbus_device():
     async def cb(r, w):
         while True:
             data = await r.readexactly(6)
             size = int.from_bytes(data[4:6], "big")
             data += await r.readexactly(size)
-            if data == REQ:
-                reply = REP
-            elif data == REQ2:
-                reply = REP2
-            elif data == REQ3_MODIFIED:
-                reply = REP3_ORIGINAL
-
-            w.write(reply)
+            w.write(TCP_REPLIES[data])
             await w.drain()
 
+    server = await _make_device(cb)
     try:
-        server = await asyncio.start_server(cb, host="127.0.0.1")
-        server.address = server.sockets[0].getsockname()
         yield server
     finally:
         server.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest_asyncio
 
-from modbus_proxy import ModBus
+from modbus_proxy import ModBus, tcp_to_rtu, read_rtu_frame
 
 # read_holding_registers(unit=1, start=1, size=4)
 #      |tid | tcp   | size  |uni|cod|s .addr|nb. reg|
@@ -15,7 +15,7 @@ REP = b"m\xf5\x00\x00\x00\x0b\x01\x03\x08\x00\x01\x00\x02\x00\x03\x00\x04"
 #       |tid | tcp   | size  |uni|cod|s .addr|nb. reg|
 REQ2 = b"m\xf5\x00\x00\x00\x06\x01\x03\x00\x02\x00\x03"
 #       |tid | tcp   | size  |uni|cod|len|   2   |   3   |   4   |
-REP2 = b"m\xf5\x00\x00\x00\x09\x01\x03\x08\x00\x02\x00\x03\x00\x04"
+REP2 = b"m\xf5\x00\x00\x00\x09\x01\x03\x06\x00\x02\x00\x03\x00\x04"
 
 
 # read_holding_registers(unit=1, start=2, size=3)
@@ -23,8 +23,62 @@ REP2 = b"m\xf5\x00\x00\x00\x09\x01\x03\x08\x00\x02\x00\x03\x00\x04"
 REQ3_ORIGINAL = b"m\xf5\x00\x00\x00\x06\xFF\x03\x00\x02\x00\x03"
 REQ3_MODIFIED = b"m\xf5\x00\x00\x00\x06\xFE\x03\x00\x02\x00\x03"
 #       |tid | tcp   | size  |uni|cod|len|   2   |   3   |   4   |
-REP3_ORIGINAL = b"m\xf5\x00\x00\x00\x09\xFE\x03\x08\x00\x02\x00\x03\x00\x04"
-REP3_MODIFIED = b"m\xf5\x00\x00\x00\x09\xFF\x03\x08\x00\x02\x00\x03\x00\x04"
+REP3_ORIGINAL = b"m\xf5\x00\x00\x00\x09\xFE\x03\x06\x00\x02\x00\x03\x00\x04"
+REP3_MODIFIED = b"m\xf5\x00\x00\x00\x09\xFF\x03\x06\x00\x02\x00\x03\x00\x04"
+
+
+# RTU versions of the above frames (payload only, no MBAP header, with CRC appended)
+#      |uni|cod|s .addr|nb. reg|  crc  |
+REQ_RTU = tcp_to_rtu(REQ)
+#      |uni|cod|len|   1   |   2   |   3   |   4   |  crc  |
+REP_RTU = tcp_to_rtu(REP)
+
+#      |uni|cod|s .addr|nb. reg|  crc  |
+REQ2_RTU = tcp_to_rtu(REQ2)
+#      |uni|cod|len|   2   |   3   |   4   |  crc  |
+REP2_RTU = tcp_to_rtu(REP2)
+
+
+async def _read_rtu_request(r):
+    """Read one RTU request frame from the fake device stream."""
+    return await read_rtu_frame(r)
+
+
+RTU_REPLIES = {REQ_RTU: REP_RTU, REQ2_RTU: REP2_RTU}
+
+
+@pytest_asyncio.fixture
+async def modbus_device_rtu():
+    async def cb(r, w):
+        while True:
+            data = await _read_rtu_request(r)
+            w.write(RTU_REPLIES[data])
+            await w.drain()
+
+    try:
+        server = await asyncio.start_server(cb, host="127.0.0.1")
+        server.address = server.sockets[0].getsockname()
+        yield server
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+@pytest_asyncio.fixture
+async def modbus_rtu(modbus_device_rtu):
+    cfg = {
+        "modbus": {
+            "url": "{}:{}".format(*modbus_device_rtu.address),
+            "mode": "rtuovertcp",
+        },
+        "listen": {"bind": "127.0.0.1:0"},
+    }
+    modbus = ModBus(cfg)
+    await modbus.start()
+    modbus.device = modbus_device_rtu
+    async with modbus:
+        yield modbus
+    modbus_device_rtu.close()
 
 
 @pytest_asyncio.fixture

--- a/tests/test_modbus_proxy.py
+++ b/tests/test_modbus_proxy.py
@@ -250,3 +250,16 @@ async def test_device_not_connected(modbus):
 
     with pytest.raises(asyncio.IncompleteReadError):
         await make_requests(modbus, [(REQ, REP)])
+
+
+@pytest.mark.parametrize(
+    "req, rep",
+    [
+        (REQ, REP),
+        (REQ2, REP2),
+    ],
+    ids=["req1", "req2"],
+)
+@pytest.mark.asyncio
+async def test_modbus_rtu(modbus_rtu, req, rep):
+    await make_requests(modbus_rtu, [(req, rep)])

--- a/tests/test_modbus_proxy.py
+++ b/tests/test_modbus_proxy.py
@@ -20,7 +20,7 @@ import pytest
 
 from modbus_proxy import parse_url, parse_args, load_config, run
 
-from .conftest import REQ, REP, REQ2, REP2, REQ3_ORIGINAL, REP3_MODIFIED
+from .conftest import REQ, REP, REQ2, REP2, REQ3_ORIGINAL, REP3_MODIFIED, REQ_RTU, REQ2_RTU
 
 
 Args = namedtuple(
@@ -263,3 +263,19 @@ async def test_device_not_connected(modbus):
 @pytest.mark.asyncio
 async def test_modbus_rtu(modbus_rtu, req, rep):
     await make_requests(modbus_rtu, [(req, rep)])
+
+
+@pytest.mark.parametrize(
+    "req, rep, rtu_req",
+    [
+        (REQ, REP, REQ_RTU),
+        (REQ2, REP2, REQ2_RTU),
+    ],
+    ids=["req1", "req2"],
+)
+@pytest.mark.asyncio
+async def test_modbus_rtu_echo(modbus_rtu_echo, req, rep, rtu_req):
+    # Verify correct replies are received despite the device echoing each request
+    await make_requests(modbus_rtu_echo, [(req, rep)])
+    # Multiple sequential requests to confirm echo stripping works consistently
+    await make_requests(modbus_rtu_echo, 3 * [(req, rep)])


### PR DESCRIPTION
This implements an optional mode (configured via `mode: rtuovertcp` in a device' `modbus` config section) where on the device side, we expect raw RTU frames instead of modbus TCP.  For instance, from a RS485-to-TCP adapter that is transparently passing over the RTU data instead of converting correctly to modbus TCP.

It also adds a `strip_rtu_echo: true/false` configuration, which can in addition strip an echo for adapters that use a full-duplex wiring with separate R and T lines, but are connected to a half-duplex device.

This implements #48.  I have tested the change with a Waveshares adapter in fully transparent mode connected to a Huawei Sun2000 inverter, which requires both changes to be applied for correct communication.